### PR TITLE
Add Flask web app and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-m", "src.webapp"]
+

--- a/README.md
+++ b/README.md
@@ -170,4 +170,22 @@ OUTPUT_DIRECTORY=transcriptions
 
 ## License
 
-MIT License 
+MIT License
+
+## Web Application
+
+In addition to the desktop GUI, a simple Flask-based web interface is available.
+Run it locally with:
+
+```bash
+python -m src.webapp
+```
+
+### Docker
+
+You can build and run the web app in a container:
+
+```bash
+docker build -t audio-transcriber .
+docker run -p 5000:5000 audio-transcriber
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ assemblyai>=0.20.0
 customtkinter>=5.2.0
 pydub>=0.25.1
 python-dotenv>=1.0.0
-certifi>=2024.2.2 
+certifi>=2024.2.2
+Flask>=3.0.0

--- a/src/webapp.py
+++ b/src/webapp.py
@@ -1,0 +1,54 @@
+import os
+from flask import Flask, request, render_template_string
+
+from src.utils.config import Config
+from src.core.audio_handler import AudioHandler
+from src.core.transcriber import Transcriber
+
+app = Flask(__name__)
+config = Config()
+audio_handler = AudioHandler(config)
+transcriber = Transcriber(config)
+
+HTML_FORM = """
+<!doctype html>
+<title>Audio Transcriber</title>
+<h1>Upload an audio file</h1>
+<form method=post enctype=multipart/form-data action="/transcribe">
+  <input type=file name=file required>
+  <input type=submit value=Transcribe>
+</form>
+{% if transcript %}
+<h2>Transcript</h2>
+<pre>{{ transcript }}</pre>
+{% endif %}
+"""
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template_string(HTML_FORM)
+
+@app.route("/transcribe", methods=["POST"])
+def transcribe_route():
+    uploaded = request.files.get("file")
+    if not uploaded:
+        return render_template_string(HTML_FORM, transcript="No file uploaded")
+
+    temp_dir = "/tmp"
+    path = os.path.join(temp_dir, uploaded.filename)
+    uploaded.save(path)
+
+    prepared = audio_handler.prepare_audio(path)
+    if not prepared:
+        return render_template_string(HTML_FORM, transcript="Failed to process file")
+
+    transcript = transcriber.transcribe_file(prepared)
+    audio_handler.cleanup_temp_file(prepared)
+    if prepared != path and os.path.exists(path):
+        os.remove(path)
+
+    return render_template_string(HTML_FORM, transcript=transcript or "Transcription failed")
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))
+


### PR DESCRIPTION
## Summary
- add Flask to dependencies
- implement a simple Flask app in `src/webapp.py`
- provide Dockerfile to containerize the web app
- document running the web app and container instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_685b78fc6d4c832e81b38137595ec1d2